### PR TITLE
Generate Kotlin for Protos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,9 @@ buildscript {
 
     ext {
         project_version = '0.3.0-SNAPSHOT'
-        grpc_version = '1.34.0'
-        protobuf_version = '3.14.0'
+        grpc_version = '1.44.1'
+        grpc_kotlin_version = '1.2.1'
+        protobuf_version = '3.17.3'
         javax_annotation_version = '1.3.1'
         lombok_version = '1.18.22'
         junit_version = '5.7.0'

--- a/saga-sdk-proto/build.gradle
+++ b/saga-sdk-proto/build.gradle
@@ -5,7 +5,9 @@ dependencies {
     api group: 'io.grpc', name: 'grpc-protobuf', version: "${grpc_version}"
     api group: 'io.grpc', name: 'grpc-stub', version: "${grpc_version}"
     api group: 'io.grpc', name: 'grpc-services', version: "${grpc_version}"
+    api group: 'io.grpc', name: 'grpc-kotlin-stub', version: "${grpc_kotlin_version}"
 
+    api group: 'com.google.protobuf', name: 'protobuf-kotlin', version: "${protobuf_version}"
     api group: 'com.google.protobuf', name: 'protobuf-java-util', version: "${protobuf_version}"
 
     implementation 'javax.annotation:javax.annotation-api:1.3.1'
@@ -26,6 +28,12 @@ protobuf {
             artifact = "io.grpc:protoc-gen-grpc-java:${grpc_version}"
         }
 
+        grpckt {
+            artifact = "io.grpc:protoc-gen-grpc-kotlin:${grpc_kotlin_version}:jdk7@jar"
+        }
+
+        kotlin {}
+
         doc {
             artifact = "io.github.pseudomuto:protoc-gen-doc:1.5.1"
         }
@@ -34,6 +42,8 @@ protobuf {
     generateProtoTasks {
         all()*.plugins {
             grpc {}
+            grpckt {}
+            kotlin {}
             doc {
                 option "${protoDocType},${protoDocFile}"
             }


### PR DESCRIPTION
This allows us to use the generated proto library for the gateway and remove the submodule and project.